### PR TITLE
remover texto incorreto

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -101,7 +101,6 @@
                     <label>Api ID</label>
                     <validate>required-entry</validate>
                 </field>
-                Token 
                 <field id="api_hash" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="40" translate="label"
                        type="text">
                     <label>Api Key</label>


### PR DESCRIPTION
Há um resquício de código quebrando o XML, ao remover o mesmo volta a funcionar corretamente.